### PR TITLE
Translated a comment in _placeholders.scss to English

### DIFF
--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -3,7 +3,7 @@
 */
 
 
-// Centrar y dar un ancho máximo igual a $container-maxwidth.
+// Focus and give a maximum width equal to $container-maxwidth.
 %max-width {
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
`_placeholders.scss` has a lot of comments in Spanish, which needs translation
The comment I translated was with help form Google Translate - The other comments doesn't make sense when translated with Google Translate