### PR TITLE
Fix Badge Color Warning

### DIFF
--- a/src/_variables.light.scss
+++ b/src/_variables.light.scss
@@ -184,7 +184,7 @@ $badges-color-map: (
   primary:              $brand-primary,
   secondary:            $brand-secondary,
   dark:                 $brand-dark,
-  gray:                 $gray,
+  light:                 $gray,
   success:              $color-success,
   error:                $color-error,
   warning:              $color-warning

--- a/src/_variables.light.scss
+++ b/src/_variables.light.scss
@@ -184,7 +184,7 @@ $badges-color-map: (
   primary:              $brand-primary,
   secondary:            $brand-secondary,
   dark:                 $brand-dark,
-  light:                 $gray,
+  light:                $gray,
   success:              $color-success,
   error:                $color-error,
   warning:              $color-warning

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -175,7 +175,7 @@ $badges-color-map: (
   primary:              $brand-primary,
   secondary:            $brand-secondary,
   dark:                 $brand-dark,
-  light:                 $gray,
+  light:                $gray,
   success:              $color-success,
   error:                $color-error,
   warning:              $color-warning

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -175,7 +175,7 @@ $badges-color-map: (
   primary:              $brand-primary,
   secondary:            $brand-secondary,
   dark:                 $brand-dark,
-  gray:                 $gray,
+  light:                 $gray,
   success:              $color-success,
   error:                $color-error,
   warning:              $color-warning


### PR DESCRIPTION
Fixes #30 

Just a simple fix to get rid of the warning message. Use class `badge-light` instead of `badge-gray`.